### PR TITLE
Updated ModuleAutoRecord to add the ability to match names to record …

### DIFF
--- a/src/com/wowza/wms/plugin/ModuleAutoRecord.java
+++ b/src/com/wowza/wms/plugin/ModuleAutoRecord.java
@@ -53,6 +53,15 @@ public class ModuleAutoRecord extends ModuleBase
 		if (logger.isDebugEnabled())
 			debugLog = true;
 
+		String streamType = appInstance.getStreamType();
+		if(streamType.contains("-record"))
+		{
+			String newStreamType = streamType.replace("-record", "");
+			appInstance.setStreamType(newStreamType);
+			
+			logger.info(CLASSNAME + ".onAppCreate[" + appInstance.getContextStr() + "] Application has " + streamType + " stream type set. Changing to " + newStreamType + " stream type to prevent conflict.", WMSLoggerIDs.CAT_application, WMSLoggerIDs.EVT_comment);
+		}
+		
 		try
 		{
 			recordType = RecordType.valueOf(appInstance.getStreamRecorderProperties().getPropertyStr("streamRecorderRecordType", recordType.toString()).toLowerCase());
@@ -70,8 +79,10 @@ public class ModuleAutoRecord extends ModuleBase
 
 		boolean recordAllStreams = appInstance.getStreamRecorderProperties().getPropertyBoolean("streamRecorderRecordAllStreams", recordType == RecordType.all);
 		recordAllStreams = appInstance.getProperties().getPropertyBoolean("streamRecorderRecordAllStreams", recordAllStreams);
+		if(recordAllStreams)
+			recordType = RecordType.all;
 
-		if (recordAllStreams || recordType == RecordType.all)
+		if (recordType == RecordType.all)
 		{
 			// Automatically record all streams as they are published. 
 			// Recorders will only be created when a stream is first published and will stay loaded after the steram unpublishes.


### PR DESCRIPTION
…and record all streams of a certain type

Added / updated the following StreamRecorder Properties:
	`streamRecorderAutoRecordDebugLog` enable debug logging for the module. debug logging is also enabled for the main StreamRecorder debug logging (streamRecorderDebugEnable) or if logger debugging is enabled
	`streamRecorderStreamNames` pipe or comma separated list of names to match. can be a single wild card `*`, complete names, regex match, wildcard prefix or wildcard suffix
	`streamRecorderRecordType` type of streams to record or how to interpret the streamRecorderStreamNames list. Valid values are:
		`all` - record all streams. Same as `streamRecorderRecordAllStreams`
		`source` - record all source streams
		`transcoder` - record all transcoder output streams
		`allow`, `whitelist` - record streams that match something the names list
		`deny`, `blacklist` - record streams that don't match something the names list
		`none` - don't automatically record any streams